### PR TITLE
修复启动报错 没有实现 collectClassConstant

### DIFF
--- a/src/Annotation/Dependency.php
+++ b/src/Annotation/Dependency.php
@@ -30,10 +30,9 @@ class Dependency implements AnnotationInterface
         DependencyCollector::collectorDependency($className, $this->identifier, $this->priority);
     }
 
-    public function collectClassConstant(string $className, ?string $target): void
-    {
-    }
+    public function collectClassConstant(string $className, ?string $target): void{
 
+    }
 
     public function collectMethod(string $className, ?string $target): void
     {


### PR DESCRIPTION
```txt
PHP Fatal error:  Class HyperfHelper\Dependency\Annotation\Dependency contains 1 abstract method and must therefore be declared abstract or implement the remaining methods (Hyperf\Di\Annotation\AnnotationInterface::collectClassConstant) in /webser/www/vendor/hyperf-helper/dependency/src/Annotation/Dependency.php on line 14
```